### PR TITLE
Add WorkingDir from JobTemplate

### DIFF
--- a/job_help.go
+++ b/job_help.go
@@ -33,6 +33,9 @@ func mergeJobTemplateWithDefaultTemplate(req, def drmaa2interface.JobTemplate) d
 	if req.JobName == "" {
 		req.JobName = def.JobName
 	}
+	if req.WorkingDirectory == "" {
+		req.WorkingDirectory = def.WorkingDirectory
+	}
 	// replaces destination machines
 	if req.CandidateMachines == nil && def.CandidateMachines != nil {
 		if cm, err := copystructure.Copy(def.CandidateMachines); err == nil {


### PR DESCRIPTION
The `JobTemplate` has a field, but it was never able to reach the docker API because `mergeJobTemplateWithDefaultTemplate` did not populate the field from the default template.

WorkingDirectory will not work without the https://github.com/dgruber/drmaa2os/pull/20 PR

It does not break things, but has zero effect without the changes in drmaa2os.